### PR TITLE
Fix invalid ESLint disable comment for TSX files

### DIFF
--- a/server/src/languageDefaults.ts
+++ b/server/src/languageDefaults.ts
@@ -29,7 +29,7 @@ namespace LanguageDefaults {
 	}
 
 	export function getBlockComment(languageId: string): [string, string] {
-		return languageId2Config.get(languageId)?.blockComment ?? ['/**', '*/'];
+		return languageId2Config.get(languageId)?.blockComment ?? ['/*', '*/'];
 	}
 
 	export function getExtension(languageId: string): string | undefined {


### PR DESCRIPTION
When using the code action to disable ESLint for the entire file, an invalid JSDoc-style comment is inserted. This comment does not effectively disable ESLint as intended.

It appears that TSX files are falling back to using an undefined array for this purpose. Although this broader issue may need further investigation, correcting the fallback array here resolves the immediate problem.